### PR TITLE
Port Launch Pad Redirect to v136

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # launchpad-redirect
 redirect all launchpads with 1 button, now for v7
-
-mindustry mod (mod browser please pick this up)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # launchpad-redirect
-redirect all launchpads with 1 button
+redirect all launchpads with 1 button, now for v7
 
 mindustry mod (mod browser please pick this up)

--- a/mod.hjson
+++ b/mod.hjson
@@ -1,8 +1,0 @@
-{
-    name: "launchpad-redirect",
-    displayName: "Launchpad Redirect",
-    author: "QmelZ",
-    version: 2,
-    minGameVersion: 126,
-    hidden: true
-}

--- a/mod.json
+++ b/mod.json
@@ -3,7 +3,7 @@
     "displayName": "Launchpad Redirect",
     "author": "QmelZ, MonoScyron",
     "description": "Allows you to redirect all launchpads with one button. Original mod made by QmelZ, v7 port by MonoScyron.",
-    "version": 3,
+    "version": 3.0,
     "minGameVersion": 136,
     "hidden": false,
     "repo": "MonoScyron/launchpad-redirect-v7"

--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-    "name": "launchpad-redirect",
+    "name": "launchpad-redirect-v7",
     "displayName": "Launchpad Redirect",
     "author": "QmelZ, MonoScyron",
     "description": "Allows you to redirect all launchpads with one button. Original mod made by QmelZ, v7 port by MonoScyron.",

--- a/mod.json
+++ b/mod.json
@@ -1,9 +1,10 @@
 {
     "name": "launchpad-redirect",
     "displayName": "Launchpad Redirect",
-    "author": "QmelZ",
-    "version": 2,
+    "author": "QmelZ, MonoScyron",
+    "description": "Allows you to redirect all launchpads with one button. Original mod made by QmelZ, v7 port by MonoScyron.",
+    "version": 3,
     "minGameVersion": 136,
     "hidden": true,
-    "repo": "Badly-Timed-Joke/launchpad-redirect-v7"
+    "repo": "MonoScyron/launchpad-redirect-v7"
 }

--- a/mod.json
+++ b/mod.json
@@ -1,0 +1,9 @@
+{
+    "name": "launchpad-redirect",
+    "displayName": "Launchpad Redirect",
+    "author": "QmelZ",
+    "version": 2,
+    "minGameVersion": 136,
+    "hidden": true,
+    "repo": "Badly-Timed-Joke/launchpad-redirect-v7"
+}

--- a/mod.json
+++ b/mod.json
@@ -3,7 +3,7 @@
     "displayName": "Launchpad Redirect",
     "author": "QmelZ, MonoScyron",
     "description": "Allows you to redirect all launchpads with one button. Original mod made by QmelZ, v7 port by MonoScyron.",
-    "version": 3.1,
+    "version": 3.2,
     "minGameVersion": 136,
     "hidden": true,
     "repo": "MonoScyron/launchpad-redirect-v7"

--- a/mod.json
+++ b/mod.json
@@ -5,6 +5,6 @@
     "description": "Allows you to redirect all launchpads with one button. Original mod made by QmelZ, v7 port by MonoScyron.",
     "version": 3,
     "minGameVersion": 136,
-    "hidden": true,
+    "hidden": false,
     "repo": "MonoScyron/launchpad-redirect-v7"
 }

--- a/mod.json
+++ b/mod.json
@@ -3,8 +3,8 @@
     "displayName": "Launchpad Redirect",
     "author": "QmelZ, MonoScyron",
     "description": "Allows you to redirect all launchpads with one button. Original mod made by QmelZ, v7 port by MonoScyron.",
-    "version": 3.0,
+    "version": 3.1,
     "minGameVersion": 136,
-    "hidden": false,
+    "hidden": true,
     "repo": "MonoScyron/launchpad-redirect-v7"
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,19 +1,33 @@
 Events.on(ClientLoadEvent, () => {
     let p = Vars.ui.planet;
+    var l;
     p.shown(() => {
-        if(p.mode === PlanetDialog.Mode.look){
+        if (p.mode === PlanetDialog.Mode.look) {
             p.fill(cons(t => {
                 t.top().left();
+                t.margin(10);
                 t.defaults().size(200, 54);
                 t.button("Redirect", Icon.upOpen, () => {
-                    let s = Planets.serpulo.sectors;
-                    p.showSelect(s.get(15), d => {
-                        s.each(e => {
-                            e.info.destination = d;
+                    if (p.state.planet.equals(Planets.serpulo)) {
+                        let s = Planets.serpulo.sectors;
+                        p.showSelect(s.get(15), d => {
+                            s.each(e => {
+                                e.info.destination = d;
+                            });
                         });
-                    });
+                        if (t.getChildren().size > 1) {
+                            t.reset();
+                        }
+                    }
+                    else {
+                        if (t.getChildren().size <= 1) {
+                            t.add("No launchpads in Erekir (yet)", Color.scarlet);
+                        }
+                    }
                 });
+                t.row();
             }));
         }
     });
 });
+

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,5 @@
 Events.on(ClientLoadEvent, () => {
     let p = Vars.ui.planet;
-    var l;
     p.shown(() => {
         if (p.mode === PlanetDialog.Mode.look) {
             p.fill(cons(t => {
@@ -10,10 +9,13 @@ Events.on(ClientLoadEvent, () => {
                 t.button("Redirect", Icon.upOpen, () => {
                     if (p.state.planet.equals(Planets.serpulo)) {
                         let s = Planets.serpulo.sectors;
-                        p.showSelect(s.get(15), d => {
+                        let currSector = Vars.state.getSector();
+                        Vars.state.rules.sector = s.get(15);
+                        p.showSelect(currSector == null ? s.get(15) : currSector, d => {
                             s.each(e => {
                                 e.info.destination = d;
                             });
+                            Vars.state.rules.sector = currSector;
                         });
                         if (t.getChildren().size > 1) {
                             t.reset();
@@ -30,4 +32,3 @@ Events.on(ClientLoadEvent, () => {
         }
     });
 });
-

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -21,7 +21,7 @@ Events.on(ClientLoadEvent, () => {
                     }
                     else {
                         if (t.getChildren().size <= 1) {
-                            t.add("No launchpads in Erekir (yet)", Color.scarlet);
+                            t.add("No launchpads here (yet)", Color.scarlet);
                         }
                     }
                 });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -3,7 +3,7 @@ Events.on(ClientLoadEvent, () => {
     p.shown(() => {
         if(p.mode === PlanetDialog.Mode.look){
             p.fill(cons(t => {
-                t.top().right();
+                t.top().left();
                 t.defaults().size(200, 54);
                 t.button("Redirect", Icon.upOpen, () => {
                     let s = Planets.serpulo.sectors;


### PR DESCRIPTION
Modified the redirect button and mod.json a bit to allow the mod to work in v136 and fixed some bugginess that happens when you redirect to the sector you're currently in.

Note, repo link in mod.json may need to be changed back to the original repo.